### PR TITLE
Fix incorrect hyphen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ To use this target between hosts 1.2.3.4 and 1.2.3.5.
 
 ### (on host A, 1.2.3.4)
 ```bash
-iptables −t mangle −A OUTPUT -d 1.2.3.5 -p tcp --dport 1234 −j XOR −−key 0x61
-iptables −t mangle −A INPUT -s 1.2.3.5 -p tcp --sport 1234 −j XOR −−key 0x61
+iptables -t mangle -A OUTPUT -d 1.2.3.5 -p tcp --dport 1234 -j XOR --key 0x61
+iptables -t mangle -A INPUT -s 1.2.3.5 -p tcp --sport 1234 -j XOR --key 0x61
 ```
 
 ### (on host B, 1.2.3.5)
 ```bash
-iptables −t mangle −A OUTPUT −d 1.2.3.4 -p tcp --sport 1234 −j XOR −−key 0x61
-iptables −t mangle −A INPUT −s 1.2.3.4 -p tcp --dport 1234 −j XOR −−key 0x61
+iptables -t mangle -A OUTPUT -d 1.2.3.4 -p tcp --sport 1234 -j XOR --key 0x61
+iptables -t mangle -A INPUT -s 1.2.3.4 -p tcp --dport 1234 -j XOR --key 0x61
 ```
 
 ### Notice


### PR DESCRIPTION
The original hyphen is `−`(\u2212), which causes iptables to report invalid option. We should use `-`(\u002d) instead.