### PR TITLE
Declare entry point explicitly instead of using macro

### DIFF
--- a/userspace/libxt_XOR.c
+++ b/userspace/libxt_XOR.c
@@ -116,7 +116,7 @@ static struct xtables_target xor_reg[] = {
     },
 };
 
-static void _init(void)
+static __attribute__((constructor)) void init_xt_xor(void)
 {
     xtables_register_targets(xor_reg,
             sizeof(xor_reg) / sizeof(*xor_reg));


### PR DESCRIPTION
As of commit `ef108943f69a6e20533d58823740d3f0534ea8ec` in `iptables`, `_init` macro in `xtables.h` was moved into internal-only block, thus breaking the initialization and registration of the userspace part of this module, when built against iptables of versions `>=1.8.9`.

This pull request explicitly marks init function as an entry point of .so.

*Should* close issue #4.